### PR TITLE
Fix spelling error - immgini -> immagini

### DIFF
--- a/localizations/it.yml
+++ b/localizations/it.yml
@@ -11,7 +11,7 @@ it:
 
 # Labels for the navigation bar
   everything: "risultati nel sito"
-  images: "immgini"
+  images: "immagini"
   videos: "videos"
   show_more: 'altro'
 


### PR DESCRIPTION
Hi @noremmie - DOS alerted us to a spelling error. This PR corrects it.