### PR TITLE
Update non_es_en_template.yml

### DIFF
--- a/localizations/non_es_en_template.yml
+++ b/localizations/non_es_en_template.yml
@@ -1,93 +1,91 @@
 ﻿non_es_en_template:
 
 # Default page title of search results page
-  default_serp_title: '%{query} - %{site_name} Որոնման արդյունքներ'
+  default_serp_title: '%{query} - %{site_name} ຜົນການຄົ້ນຫາ'
 
 # Labels for the search box
-  search: "Որոնել"
-  search_label: 'Որոնման բանալի բառ'
+  search: "ຄົ້ນຫາ"
+  search_label: 'ກະລຸນາໃສ່ຄຳສັບທີ່ທ່ານຢາກຄົ້ນຫາ'
 
 # Labels for the navigation bar
-  everything: "Արդյունքներ ըստ կայքի"
-  images: "Նկարներ"
-  videos: "Տեսանյութեր"
-  show_more: 'Ըստ աշխարհագրական դիրքի'
+  everything: "ຜົນການຄົ້ນຫາເວັບໄຊ"
+  images: "ຮູບພາບ"
+  show_more: 'ເພີ້ມຕື່ມ'
 
 # Labels to change the sort order by date or relevance
-  by_date: 'Վերջին արդյունքներ'
-  by_relevance: 'Լավագույն համապատասխանություն'
+  by_date: 'ຫວ່າງບໍ່ດົນມານີ້'
+  by_relevance: 'ໃກ້ຄຽງທີ່ສຸດ'
 
 # Labels to narrow results by a preset timeframe or a custom date range, or clear filters ('Before' is the label for custom date range with only a 'To' date set.)
   refine_your_search:
-  all_time: "Ամբողջ ընթացքում"
-  last_hour: "Վերջին ժամում"
-  last_day: "Վերջին օրը"
-  last_week: "Վերջին շաբաթում"
-  last_month: "Վերջին ամսում"
-  last_year: "Վերջին տարում"
-  custom_range: 'Կամայական ժամանակահատված'
-  from: 'Ումից'
-  to: 'Ում'
+  all_time: "ຕະຫຼອດເວລາ"
+  last_hour: "ຊົ່ວໂມງຜ່ານມາ"
+  last_day: "ມື້ທີ່ຜ່ານມາ"
+  last_week: "ອາທິດຜ່ານມາ"
+  last_month: "ເດືອນທີ່ຜ່ານມາ"
+  last_year: "ປີຜ່ານມາ"
+  custom_range: 'ລະດັບທີ່ກຳນົດ'
+  from: 'ຈາກ'
+  to: 'ເຖິງ'
 # It's safe to modify the order of these (e.g., '%m/%d/%Y'), but do not localize the Latin letters 'd', 'm', or 'Y'. Do not change the case of the letters.
   cdr_format: '%d/%m/%Y'
-  before: 'Մինչև'
-  clear: 'Մաքրել'
+  before: 'ກ່ອນ'
+  clear: 'ລົບລ້າງ'
 
 # Prompts for spelling, spelling overrides, and did you mean suggestions
-  showing_results_for: Ցուցադրվում է որոնման արդյունքներ %{corrected_query}
-  search_instead_for: Փոխարենը որոնել %{original_query}
-  did_you_mean: "Ներառված են որոնման արդյունքներ %{assumed_term}. Ցուցադրել միայն հետևյալ որոնման արդյունքները %{term_as_typed}?"
+  showing_results_for: ສະແດງຜົນການຄົ້ນຫາ %{corrected_query}
+  search_instead_for: ຄົ້ນຫາແທນ %{original_query}
+  did_you_mean: "ທ່ານຕ້ອງການເບິ່ງຂໍ້ມູນເພື່ອ %{assumed_term}. ການຄົ້ນຫາຫຼາຍຂຶ້ນ %{term_as_typed}?"
 
 # Prompts for searchers to revise or refine search
-  no_results_for_and_try: "Ցավոք, որոնման արդյունքներ չկան '%{query}'. Փորձեք ավելացնել կամ պակասեցնել բանալի բառերը."
-  too_long: "Որոնվող արտահայտությունը շատ երկար է: Փորձեք կրկին օգտագործելով ավելի կարճ արտահայտություն:."
-  empty_query: "Մուտքագրեք որոնվող արտահայտությունը վերևի դաշտում."
+  no_results_for_and_try: "ຂໍອະໄພ, ບໍ່ພົບເຫັນຜົນການຄົ້ນຫາ '%{query}'. ລອງໃສ່ຄຳສັບຄົ້ນຫາໃໝ່."
+  too_long: "ຄຳສັບທີ່ກຳລັງຄົ້ນຫາ ຍາວເກີນໄປ: ກະລຸນາໃຊ້ຄຳສັບສັ້ນກວ່າເກົ່າ."
+  empty_query: "ກະລຸນາໃສ່ຄຳສັບຄົ້ນຫາທີ່ຢູ່ທາງດ້ານເທິງ."
 
 # Labels for inline best bets, news, and related searches modules
-  recommended: "Խորհուրդ է տրվում"
-  by: "Ում միջոցով"
-  default_rss_govbox_label: 'Նորություններ'
-  related_searches: "Առնչվող որոնումներ"
+  recommended: "ແນະນຳ"
+  by: "ໂດຍ"
+  related_searches: "ການຄົ້ນຫາທີ່ກ່ຽວຂ້ອງ"
 
 # Labels for paging through results
-  page: 'Էջ'
-  prev_label: "Նախորդ"
-  next_label: "Հաջորդ"
+  page: 'ໜ້າ'
+  prev_label: "ທີ່ຜ່ານມາ"
+  next_label: "ຕໍ່ໄປ"
   
   searches:
     by: by
 # Prompt for searchers to skip to main content (most easily seen by tabbing through results page)
-    skip_to_main_content: Անցնել հիմնական բովանդակությանը
+    skip_to_main_content: ກັບໄປສູ່ໜ້າຫຼັກ
 # Labels for navigation bar "sections" (most easily seen on mobile dimension)
-    menu: Մենյու
-    browse_site: Որոնել էջում
-    related_sites: Դիտել թեմանc
-    results_count: '%{count} արդյունքներ'
-    search_results: Որոնման արդյունքներ
+    menu: ລາຍການ
+    browse_site: ໝວດເວັບໄຊ
+    related_sites: ຫົວຂໍ້ທີ່ກ່ຽວຂ້ອງ
+    results_count: '%{count} ຜົນການຄົ້ນຫາ'
+    search_results: ຜົນການຄົ້ນຫາ
 # Prompts for searchers to view more results from Bing/Google after reaching page n of DigitalGov Search results
     commercial_results:
       find_what_looking_for:
-      see_more_web_results: "%{link} Ավելին. (Հնարավոր է ընդգրկվեն նախկինում հանդիպած որոնման արդյունքներ.)"
-      see_more_image_results: "Որոնման արդյունքները վերցված են մեր սոցիալական ցանցերից և պատկերասրահներից. %{link} Որոնման արդյունքներ մեր էջից. (Հնարավոր է ընդգրկվեն նախկինում հանդիպած որոնման արդյունքներ.)"
-      search_again: Կրկնել որոնումը
+      see_more_web_results: "%{link} ການຄົ້ນຫາຫຼາຍຂຶ້ນ. (ທ່ານອາດພົບຂໍ້ມູນ ທີ່ທ່ານເຄີຍເຫັນແລ້ວ.)"
+      see_more_image_results: "ຂໍ້ມູນດ້ານເທິງ ແມ່ນມາຈາກ ມີເດຍ ແລະ ແກລໍຣີ. %{link} (ທ່ານອາດພົບຂໍ້ມູນ ທີ່ທ່ານເຄີຍເຫັນແລ້ວ.)"
+      search_again: ກະລຸນາໃສ່ຄຳສັບທີ່ຄົ້ນຫາອີກຄັ້ງ
 # Prompts for searchers to view more results from the broader website after initially seeing site-scoped results
     site_limits:
       including_results_for_query_from_matching_sites: Ներառված են որոնման արդյունքներ %{query} Ումից %{matching_sites} Միայն.
-      do_you_want_to_see_results_for: Տեսնել որոնման արդյունքներ %{query_from_all_sites}?
-      query_from_all_sites: '%{query} Բոլոր կայքէջերից'
+      do_you_want_to_see_results_for: ທ່ານຕ້ອງການເບິ່ງຂໍ້ມູນເພື່ອ %{query_from_all_sites}?
+      query_from_all_sites: '%{query} ຈາກເວັບໄຊທັງໝົດ'
 # Label for inline news module and prompt to see more news on news vertical
-    more_news_about_query: 'Ավելին %{news_label} Մասին %{query}'
-    news_about_query: '%{news_label} Մասին %{query}'
+    more_news_about_query: 'ເພີ້ມຕື່ມ %{news_label} ກ່ຽວກັບ %{query}'
+    news_about_query: '%{news_label} ກ່ຽວກັບ %{query}'
     news_search_options:
 # It's safe to modify the order of these (e.g., 'm/d/yyyy'), but do not localize 'd', 'm', or 'yyyy'. Do not change the case of the letters.
       date_format: 'd/m/yyyy'
 
 # Label for attributing results to Bing, DigitalGov Search, or Google
-  powered_by: 'Գործարկվել է շնորհիվ'
+  powered_by: ສະໜັບສະໜູນໂດຍ'
 
 # Prompts for searchers to expand/collapse the number of best bets visible on the results page
-  show_more_label: 'Ցույց տալ ավելին'
-  show_less_label: 'Ցույց տալ պակաս'
+  show_more_label: 'ສະແດງເພີ່ມຕື່ມ'
+  show_less_label: 'ສະແດງໜ້ອຍລົງ'
 
 # Date format used in custom date range picker and other places
   date:
@@ -98,37 +96,37 @@
 # Labels for news-based results indicating how long ago they were published
   datetime:
     time_ago_in_words:
-      half_a_minute: "Կես րոպե առաջ"
+      half_a_minute: "ເຄິ່ງນາທີຜ່ານມາ"
       less_than_x_seconds:
-        one:   "Մեկ վայրկյանից քիչ ժամանակ առաջ"
-        other: "Ավելի քիչ քան %{count} Վայրկյաններ առաջ"
+        one:   "ໜ້ອຍກວ່າ 1 ວິນາທີ"
+        other: "ໜ້ອຍກວ່າ %{count} ວິນາທີ"
       x_seconds:
-        one:   "1 վայրկյան առաջ"
-        other: "%{count} Վայրկյաններ առաջ"
+        one:   "1 ໜຶ່ງນາທີ ຜ່ານມາ"
+        other: "%{count} ສອງນາທີ ຜ່ານມາ"
       less_than_x_minutes:
-        one:   "Մեկ րոպեից քիչ ժամանակ առաջ"
-        other: "Ավելի քիչ քան %{count} Րոպեներ առաջ"
+        one:   "ໜ້ອຍກວ່າ1ນາທີ່ຜ່ານມາ"
+        other: "2 ຫາ 3ນາທີຜ່ານມາ %{count} ນາທີຜ່ານມາ"
       x_minutes:
-        one:   "1 րոպե առաջ"
-        other: "%{count} Րոպեներ առաջ"
+        one:   "1 ນາທີຜ່ານມາ"
+        other: "%{count} ນາທີຜ່ານມາ"
       about_x_hours:
-        one:   "Մոտ 1 ժամ առաջ"
-        other: "Մասին %{count} Ժամեր առաջ"
+        one:   "ປະມານ1 ຊົ່ວໂມງຜ່ານມາ"
+        other: "ຫາ %{count} ຊົ່ວໂມງຜ່ານມາ"
       x_days:
-        one:   "1 օր առաջ"
-        other: "%{count} Օրեր առաջ"
+        one:   "1 ມື້ຜ່ານມາ"
+        other: "%{count} ຫາ ໝືຜ່ານມາ"
       about_x_months:
-        one:   "Մոտ մեկ ամիս առաջ"
-        other: "Մասին %{count} Ամիսներ առաջ"
+        one:   "ປະມານ 1 ເດືອນຜ່ານມາ"
+        other: "ຫາ %{count} ເດືອນຜ່ານມາ"
       x_months:
-        one:   "1 ամիս առաջ"
-        other: "%{count} Ամիսներ առաջ"
+        one:   "ປະມານ 1 ເດືອນຜ່ານມາ"
+        other: "%{count} ເດືອນຜ່ານມາ"
       about_x_years:
-        one:   "Մոտ մեկ տարի առաջ"
-        other: "Մասին %{count} Տարիներ առաջ"
+        one:   "1 ປີຜ່ານມາ"
+        other: " %{count} ປີຜ່ານມາ"
       over_x_years:
-        one:   "Մեկ տարուց ավելի առաջ"
-        other: "Մեկ %{count} Տարիներ առաջ"
+        one:   "ຫຼາຍກວ່າ1ປີຜ່ານມາ"
+        other: " %{count} ປີຜ່ານມາ"
       almost_x_years:
-        one:   "Մոտավորապես 1 տարի առաջ"
+        one:   "ເກືອບ1ປີຜ່ານມາ"
         other: "Մոտավորապես %{count} Տարիներ առաջ"


### PR DESCRIPTION
Site localizations for Lao language

non_es_en_template:
 
 # Default page title of search results page
-  default_serp_title: '%{query} - %{site_name} Որոնման արդյունքներ'
+  default_serp_title: '%{query} - %{site_name} ຜົນການຄົ້ນຫາ'
 
 # Labels for the search box
-  search: "Որոնել"
-  search_label: 'Որոնման բանալի բառ'
+  search: "ຄົ້ນຫາ"
+  search_label: 'ກະລຸນາໃສ່ຄຳສັບທີ່ທ່ານຢາກຄົ້ນຫາ'
 
 # Labels for the navigation bar
-  everything: "Արդյունքներ ըստ կայքի"
-  images: "Նկարներ"
-  videos: "Տեսանյութեր"
-  show_more: 'Ըստ աշխարհագրական դիրքի'
+  everything: "ຜົນການຄົ້ນຫາເວັບໄຊ"
+  images: "ຮູບພາບ"
+  show_more: 'ເພີ້ມຕື່ມ'
 
 # Labels to change the sort order by date or relevance
-  by_date: 'Վերջին արդյունքներ'
-  by_relevance: 'Լավագույն համապատասխանություն'
+  by_date: 'ຫວ່າງບໍ່ດົນມານີ້'
+  by_relevance: 'ໃກ້ຄຽງທີ່ສຸດ'
 
 # Labels to narrow results by a preset timeframe or a custom date range, or clear filters ('Before' is the label for custom date range with only a 'To' date set.)
   refine_your_search:
-  all_time: "Ամբողջ ընթացքում"
-  last_hour: "Վերջին ժամում"
-  last_day: "Վերջին օրը"
-  last_week: "Վերջին շաբաթում"
-  last_month: "Վերջին ամսում"
-  last_year: "Վերջին տարում"
-  custom_range: 'Կամայական ժամանակահատված'
-  from: 'Ումից'
-  to: 'Ում'
+  all_time: "ຕະຫຼອດເວລາ"
+  last_hour: "ຊົ່ວໂມງຜ່ານມາ"
+  last_day: "ມື້ທີ່ຜ່ານມາ"
+  last_week: "ອາທິດຜ່ານມາ"
+  last_month: "ເດືອນທີ່ຜ່ານມາ"
+  last_year: "ປີຜ່ານມາ"
+  custom_range: 'ລະດັບທີ່ກຳນົດ'
+  from: 'ຈາກ'
+  to: 'ເຖິງ'
 # It's safe to modify the order of these (e.g., '%m/%d/%Y'), but do not localize the Latin letters 'd', 'm', or 'Y'. Do not change the case of the letters.
   cdr_format: '%d/%m/%Y'
-  before: 'Մինչև'
-  clear: 'Մաքրել'
+  before: 'ກ່ອນ'
+  clear: 'ລົບລ້າງ'
 
 # Prompts for spelling, spelling overrides, and did you mean suggestions
-  showing_results_for: Ցուցադրվում է որոնման արդյունքներ %{corrected_query}
-  search_instead_for: Փոխարենը որոնել %{original_query}
-  did_you_mean: "Ներառված են որոնման արդյունքներ %{assumed_term}. Ցուցադրել միայն հետևյալ որոնման արդյունքները %{term_as_typed}?"
+  showing_results_for: ສະແດງຜົນການຄົ້ນຫາ %{corrected_query}
+  search_instead_for: ຄົ້ນຫາແທນ %{original_query}
+  did_you_mean: "ທ່ານຕ້ອງການເບິ່ງຂໍ້ມູນເພື່ອ %{assumed_term}. ການຄົ້ນຫາຫຼາຍຂຶ້ນ %{term_as_typed}?"
 
 # Prompts for searchers to revise or refine search
-  no_results_for_and_try: "Ցավոք, որոնման արդյունքներ չկան '%{query}'. Փորձեք ավելացնել կամ պակասեցնել բանալի բառերը."
-  too_long: "Որոնվող արտահայտությունը շատ երկար է: Փորձեք կրկին օգտագործելով ավելի կարճ արտահայտություն:."
-  empty_query: "Մուտքագրեք որոնվող արտահայտությունը վերևի դաշտում."
+  no_results_for_and_try: "ຂໍອະໄພ, ບໍ່ພົບເຫັນຜົນການຄົ້ນຫາ '%{query}'. ລອງໃສ່ຄຳສັບຄົ້ນຫາໃໝ່."
+  too_long: "ຄຳສັບທີ່ກຳລັງຄົ້ນຫາ ຍາວເກີນໄປ: ກະລຸນາໃຊ້ຄຳສັບສັ້ນກວ່າເກົ່າ."
+  empty_query: "ກະລຸນາໃສ່ຄຳສັບຄົ້ນຫາທີ່ຢູ່ທາງດ້ານເທິງ."
 
 # Labels for inline best bets, news, and related searches modules
-  recommended: "Խորհուրդ է տրվում"
-  by: "Ում միջոցով"
-  default_rss_govbox_label: 'Նորություններ'
-  related_searches: "Առնչվող որոնումներ"
+  recommended: "ແນະນຳ"
+  by: "ໂດຍ"
+  related_searches: "ການຄົ້ນຫາທີ່ກ່ຽວຂ້ອງ"
 
 # Labels for paging through results
-  page: 'Էջ'
-  prev_label: "Նախորդ"
-  next_label: "Հաջորդ"
+  page: 'ໜ້າ'
+  prev_label: "ທີ່ຜ່ານມາ"
+  next_label: "ຕໍ່ໄປ"
   
   searches:
     by: by
 # Prompt for searchers to skip to main content (most easily seen by tabbing through results page)
-    skip_to_main_content: Անցնել հիմնական բովանդակությանը
+    skip_to_main_content: ກັບໄປສູ່ໜ້າຫຼັກ
 # Labels for navigation bar "sections" (most easily seen on mobile dimension)
-    menu: Մենյու
-    browse_site: Որոնել էջում
-    related_sites: Դիտել թեմանc
-    results_count: '%{count} արդյունքներ'
-    search_results: Որոնման արդյունքներ
+    menu: ລາຍການ
+    browse_site: ໝວດເວັບໄຊ
+    related_sites: ຫົວຂໍ້ທີ່ກ່ຽວຂ້ອງ
+    results_count: '%{count} ຜົນການຄົ້ນຫາ'
+    search_results: ຜົນການຄົ້ນຫາ
 # Prompts for searchers to view more results from Bing/Google after reaching page n of DigitalGov Search results
     commercial_results:
       find_what_looking_for:
-      see_more_web_results: "%{link} Ավելին. (Հնարավոր է ընդգրկվեն նախկինում հանդիպած որոնման արդյունքներ.)"
-      see_more_image_results: "Որոնման արդյունքները վերցված են մեր սոցիալական ցանցերից և պատկերասրահներից. %{link} Որոնման արդյունքներ մեր էջից. (Հնարավոր է ընդգրկվեն նախկինում հանդիպած որոնման արդյունքներ.)"
-      search_again: Կրկնել որոնումը
+      see_more_web_results: "%{link} ການຄົ້ນຫາຫຼາຍຂຶ້ນ. (ທ່ານອາດພົບຂໍ້ມູນ ທີ່ທ່ານເຄີຍເຫັນແລ້ວ.)"
+      see_more_image_results: "ຂໍ້ມູນດ້ານເທິງ ແມ່ນມາຈາກ ມີເດຍ ແລະ ແກລໍຣີ. %{link} (ທ່ານອາດພົບຂໍ້ມູນ ທີ່ທ່ານເຄີຍເຫັນແລ້ວ.)"
+      search_again: ກະລຸນາໃສ່ຄຳສັບທີ່ຄົ້ນຫາອີກຄັ້ງ
 # Prompts for searchers to view more results from the broader website after initially seeing site-scoped results
     site_limits:
       including_results_for_query_from_matching_sites: Ներառված են որոնման արդյունքներ %{query} Ումից %{matching_sites} Միայն.
-      do_you_want_to_see_results_for: Տեսնել որոնման արդյունքներ %{query_from_all_sites}?
-      query_from_all_sites: '%{query} Բոլոր կայքէջերից'
+      do_you_want_to_see_results_for: ທ່ານຕ້ອງການເບິ່ງຂໍ້ມູນເພື່ອ %{query_from_all_sites}?
+      query_from_all_sites: '%{query} ຈາກເວັບໄຊທັງໝົດ'
 # Label for inline news module and prompt to see more news on news vertical
-    more_news_about_query: 'Ավելին %{news_label} Մասին %{query}'
-    news_about_query: '%{news_label} Մասին %{query}'
+    more_news_about_query: 'ເພີ້ມຕື່ມ %{news_label} ກ່ຽວກັບ %{query}'
+    news_about_query: '%{news_label} ກ່ຽວກັບ %{query}'
     news_search_options:
 # It's safe to modify the order of these (e.g., 'm/d/yyyy'), but do not localize 'd', 'm', or 'yyyy'. Do not change the case of the letters.
       date_format: 'd/m/yyyy'
 
 # Label for attributing results to Bing, DigitalGov Search, or Google
-  powered_by: 'Գործարկվել է շնորհիվ'
+  powered_by: ສະໜັບສະໜູນໂດຍ'
 
 # Prompts for searchers to expand/collapse the number of best bets visible on the results page
-  show_more_label: 'Ցույց տալ ավելին'
-  show_less_label: 'Ցույց տալ պակաս'
+  show_more_label: 'ສະແດງເພີ່ມຕື່ມ'
+  show_less_label: 'ສະແດງໜ້ອຍລົງ'
 
 # Date format used in custom date range picker and other places
   date:
 @@ -98,37 +96,37 @@
 # Labels for news-based results indicating how long ago they were published
   datetime:
     time_ago_in_words:
-      half_a_minute: "Կես րոպե առաջ"
+      half_a_minute: "ເຄິ່ງນາທີຜ່ານມາ"
       less_than_x_seconds:
-        one:   "Մեկ վայրկյանից քիչ ժամանակ առաջ"
-        other: "Ավելի քիչ քան %{count} Վայրկյաններ առաջ"
+        one:   "ໜ້ອຍກວ່າ 1 ວິນາທີ"
+        other: "ໜ້ອຍກວ່າ %{count} ວິນາທີ"
       x_seconds:
-        one:   "1 վայրկյան առաջ"
-        other: "%{count} Վայրկյաններ առաջ"
+        one:   "1 ໜຶ່ງນາທີ ຜ່ານມາ"
+        other: "%{count} ສອງນາທີ ຜ່ານມາ"
       less_than_x_minutes:
-        one:   "Մեկ րոպեից քիչ ժամանակ առաջ"
-        other: "Ավելի քիչ քան %{count} Րոպեներ առաջ"
+        one:   "ໜ້ອຍກວ່າ1ນາທີ່ຜ່ານມາ"
+        other: "2 ຫາ 3ນາທີຜ່ານມາ %{count} ນາທີຜ່ານມາ"
       x_minutes:
-        one:   "1 րոպե առաջ"
-        other: "%{count} Րոպեներ առաջ"
+        one:   "1 ນາທີຜ່ານມາ"
+        other: "%{count} ນາທີຜ່ານມາ"
       about_x_hours:
-        one:   "Մոտ 1 ժամ առաջ"
-        other: "Մասին %{count} Ժամեր առաջ"
+        one:   "ປະມານ1 ຊົ່ວໂມງຜ່ານມາ"
+        other: "ຫາ %{count} ຊົ່ວໂມງຜ່ານມາ"
       x_days:
-        one:   "1 օր առաջ"
-        other: "%{count} Օրեր առաջ"
+        one:   "1 ມື້ຜ່ານມາ"
+        other: "%{count} ຫາ ໝືຜ່ານມາ"
       about_x_months:
-        one:   "Մոտ մեկ ամիս առաջ"
-        other: "Մասին %{count} Ամիսներ առաջ"
+        one:   "ປະມານ 1 ເດືອນຜ່ານມາ"
+        other: "ຫາ %{count} ເດືອນຜ່ານມາ"
       x_months:
-        one:   "1 ամիս առաջ"
-        other: "%{count} Ամիսներ առաջ"
+        one:   "ປະມານ 1 ເດືອນຜ່ານມາ"
+        other: "%{count} ເດືອນຜ່ານມາ"
       about_x_years:
-        one:   "Մոտ մեկ տարի առաջ"
-        other: "Մասին %{count} Տարիներ առաջ"
+        one:   "1 ປີຜ່ານມາ"
+        other: " %{count} ປີຜ່ານມາ"
       over_x_years:
-        one:   "Մեկ տարուց ավելի առաջ"
-        other: "Մեկ %{count} Տարիներ առաջ"
+        one:   "ຫຼາຍກວ່າ1ປີຜ່ານມາ"
+        other: " %{count} ປີຜ່ານມາ"
       almost_x_years:
-        one:   "Մոտավորապես 1 տարի առաջ"
+        one:   "ເກືອບ1ປີຜ່ານມາ"
         other: "Մոտավորապես %{count} Տարիներ առաջ"
