### PR TITLE
SRCH-662 fix the suggested query prompts

### DIFF
--- a/localizations/en.yml
+++ b/localizations/en.yml
@@ -35,8 +35,8 @@ en:
   clear: 'Clear'
 
 # Prompts for spelling, spelling overrides, and did you mean suggestions
-  showing_results_for: Showing results for %{corrected_query}
-  search_instead_for: Search instead for %{original_query}
+  showing_results_for: No results for %{original_query}. Showing results for %{corrected_query}.
+  search_instead_for: Search instead for %{original_query}?
   did_you_mean: "We're including results for %{assumed_term}. Do you want results only for %{term_as_typed}?"
 
 # Prompts for searchers to revise or refine search


### PR DESCRIPTION
* Clarifies that we're showing results for a different query because there were no results for the original query.
* Adds a `?` to search_instead_for